### PR TITLE
Add support for gjs/gts files

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,13 @@ export default {
   babelParserPlugins: ['jsx'],
   extensions: ['.jsx'],
 };
+
+Gts example
+```js
+export default {
+  babelParserPlugins: ['typescript'],
+  extensions: ['.gts'],
+};
 ```
 
 ### `--fix`

--- a/__snapshots__/test.js.snap
+++ b/__snapshots__/test.js.snap
@@ -93,6 +93,20 @@ exports[`Test Fixtures external-addon-translations 1`] = `
 
 exports[`Test Fixtures external-addon-translations 2`] = `Map {}`;
 
+exports[`Test Fixtures first-class-component-templates 1`] = `
+"[1/4] 🔍  Finding JS and HBS files...
+[2/4] 🔍  Searching for translations keys in JS and HBS files...
+[3/4] ⚙️   Checking for unused translations...
+[4/4] ⚙️   Checking for missing translations...
+
+ 👏  No unused translations were found!
+
+ 👏  No missing translations were found!
+"
+`;
+
+exports[`Test Fixtures first-class-component-templates 2`] = `Map {}`;
+
 exports[`Test Fixtures in-repo-translations 1`] = `
 "[1/4] 🔍  Finding JS and HBS files...
 [2/4] 🔍  Searching for translations keys in JS and HBS files...

--- a/fixtures/first-class-component-templates/app/templates/class-based.gjs
+++ b/fixtures/first-class-component-templates/app/templates/class-based.gjs
@@ -1,0 +1,13 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+export default class Foo extends Component {
+  @tracked foo;
+  foo() {
+    return this.intl.t(true ? 'js-translation' : 'js-translation2');
+  }
+
+  <template>
+    {{t (if true "hbs-translation" "hbs-translation2")}}
+  </template>
+}

--- a/fixtures/first-class-component-templates/app/templates/class-based.gts
+++ b/fixtures/first-class-component-templates/app/templates/class-based.gts
@@ -1,0 +1,13 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+export default class Foo extends Component {
+  @tracked foo;
+  foo(): string {
+    return this.intl.t(true ? 'ts-translation' : 'ts-translation2');
+  }
+
+  <template>
+    {{t (if true "ts-translation3" "ts-translation4")}}
+  </template>
+}

--- a/fixtures/first-class-component-templates/app/templates/multiple-templates.gjs
+++ b/fixtures/first-class-component-templates/app/templates/multiple-templates.gjs
@@ -1,0 +1,17 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+export const Bar = <template>
+  {{t "hbs-translation3"}}
+</template>
+
+export default class Foo extends Component {
+  @tracked foo;
+  foo() {
+    return this.intl.t(true ? 'js-translation3' : 'js-translation4');
+  }
+
+  <template>
+    {{t (if true "hbs-translation4" "hbs-translation5")}}
+  </template>
+}

--- a/fixtures/first-class-component-templates/translations/en.json
+++ b/fixtures/first-class-component-templates/translations/en.json
@@ -1,0 +1,16 @@
+{
+    "hbs-translation": "Conditional HBS!",
+    "hbs-translation2": "Conditional HBS!",
+    "hbs-translation3": "HBS!",
+    "hbs-translation4": "Conditional HBS!",
+    "hbs-translation5": "Conditional HBS!",
+    "js-translation": "JS!",
+    "js-translation2": "Conditional JS!",
+    "js-translation3": "JS!",
+    "js-translation4": "Conditional JS!",
+    "ts-translation": "TS!",
+    "ts-translation2": "TS!",
+    "ts-translation3": "TS!",
+    "ts-translation4": "TS!"
+  }
+  

--- a/index.js
+++ b/index.js
@@ -126,13 +126,13 @@ function readConfig(cwd) {
   return config;
 }
 
-function findAppFiles(cwd, userExtensions) {
+async function findAppFiles(cwd, userExtensions) {
   let extensions = [...DEFAULT_EXTENSIONS, ...userExtensions];
   let pathsWithExtensions = extensions.map(extension => 'app/**/*' + extension);
   return globby(pathsWithExtensions, { cwd });
 }
 
-function findInRepoFiles(cwd, userExtensions) {
+async function findInRepoFiles(cwd, userExtensions) {
   let inRepoPaths = findInRepoPaths(cwd);
   let inRepoFolders = joinPaths(inRepoPaths, ['addon', 'app']);
 
@@ -154,7 +154,7 @@ function findExternalTranslationFiles(cwd, config) {
   return findTranslationFiles(cwd, joinPaths('node_modules', config.externalPaths), config);
 }
 
-function findTranslationFiles(cwd, inputFolders, config) {
+async function findTranslationFiles(cwd, inputFolders, config) {
   let translationPaths = joinPaths(inputFolders, ['translations']);
 
   return globby(

--- a/index.js
+++ b/index.js
@@ -142,7 +142,7 @@ async function findInRepoFiles(cwd, userExtensions) {
   return globby(joinPaths(inRepoFolders, pathsWithExtensions), { cwd });
 }
 
-function findOwnTranslationFiles(cwd, config) {
+async function findOwnTranslationFiles(cwd, config) {
   return findTranslationFiles(cwd, ['', ...findInRepoPaths(cwd)], config);
 }
 

--- a/index.js
+++ b/index.js
@@ -10,7 +10,10 @@ const traverse = require('@babel/traverse').default;
 const Glimmer = require('@glimmer/syntax');
 const Emblem = require('emblem').default;
 const YAML = require('yaml');
-const DEFAULT_EXTENSIONS = ['.js', '.hbs', '.emblem'];
+const DEFAULT_EXTENSIONS = ['.js', '.hbs', '.emblem', '.gjs'];
+const { Preprocessor } = require('content-tag');
+
+let contentTag = new Preprocessor();
 
 async function run(rootDir, options = {}) {
   let log = options.log || console.log;
@@ -30,10 +33,17 @@ async function run(rootDir, options = {}) {
   let analyzeConcatExpression = options.analyzeConcatExpression || config.analyzeConcatExpression;
   let userPlugins = config.babelParserPlugins || [];
   let userExtensions = config.extensions || [];
+  let includeGtsExtension = userExtensions.includes('.gts');
+
   userExtensions = userExtensions.map(extension =>
     extension.startsWith('.') ? extension : `.${extension}`
   );
-  let analyzeOptions = { analyzeConcatExpression, userPlugins, userExtensions };
+  let analyzeOptions = {
+    analyzeConcatExpression,
+    userPlugins,
+    userExtensions,
+    includeGtsExtension,
+  };
 
   log(`${step(1)} 🔍  Finding JS and HBS files...`);
   let appFiles = await findAppFiles(rootDir, userExtensions);
@@ -41,17 +51,14 @@ async function run(rootDir, options = {}) {
   let files = [...appFiles, ...inRepoFiles];
 
   log(`${step(2)} 🔍  Searching for translations keys in JS and HBS files...`);
-  let usedTranslationKeys = await analyzeFiles(rootDir, files, analyzeOptions);
+  let usedTranslationKeys = analyzeFiles(rootDir, files, analyzeOptions);
 
   log(`${step(3)} ⚙️   Checking for unused translations...`);
 
   let ownTranslationFiles = await findOwnTranslationFiles(rootDir, config);
   let externalTranslationFiles = await findExternalTranslationFiles(rootDir, config);
-  let existingOwnTranslationKeys = await analyzeTranslationFiles(rootDir, ownTranslationFiles);
-  let existingExternalTranslationKeys = await analyzeTranslationFiles(
-    rootDir,
-    externalTranslationFiles
-  );
+  let existingOwnTranslationKeys = analyzeTranslationFiles(rootDir, ownTranslationFiles);
+  let existingExternalTranslationKeys = analyzeTranslationFiles(rootDir, externalTranslationFiles);
   let existingTranslationKeys = mergeMaps(
     existingOwnTranslationKeys,
     existingExternalTranslationKeys
@@ -119,13 +126,13 @@ function readConfig(cwd) {
   return config;
 }
 
-async function findAppFiles(cwd, userExtensions) {
+function findAppFiles(cwd, userExtensions) {
   let extensions = [...DEFAULT_EXTENSIONS, ...userExtensions];
   let pathsWithExtensions = extensions.map(extension => 'app/**/*' + extension);
   return globby(pathsWithExtensions, { cwd });
 }
 
-async function findInRepoFiles(cwd, userExtensions) {
+function findInRepoFiles(cwd, userExtensions) {
   let inRepoPaths = findInRepoPaths(cwd);
   let inRepoFolders = joinPaths(inRepoPaths, ['addon', 'app']);
 
@@ -135,11 +142,11 @@ async function findInRepoFiles(cwd, userExtensions) {
   return globby(joinPaths(inRepoFolders, pathsWithExtensions), { cwd });
 }
 
-async function findOwnTranslationFiles(cwd, config) {
+function findOwnTranslationFiles(cwd, config) {
   return findTranslationFiles(cwd, ['', ...findInRepoPaths(cwd)], config);
 }
 
-async function findExternalTranslationFiles(cwd, config) {
+function findExternalTranslationFiles(cwd, config) {
   if (!config.externalPaths) {
     return [];
   }
@@ -147,7 +154,7 @@ async function findExternalTranslationFiles(cwd, config) {
   return findTranslationFiles(cwd, joinPaths('node_modules', config.externalPaths), config);
 }
 
-async function findTranslationFiles(cwd, inputFolders, config) {
+function findTranslationFiles(cwd, inputFolders, config) {
   let translationPaths = joinPaths(inputFolders, ['translations']);
 
   return globby(
@@ -177,11 +184,11 @@ function joinPaths(inputPathOrPaths, outputPaths) {
   }
 }
 
-async function analyzeFiles(cwd, files, options) {
+function analyzeFiles(cwd, files, options) {
   let allTranslationKeys = new Map();
 
   for (let file of files) {
-    let translationKeys = await analyzeFile(cwd, file, options);
+    let translationKeys = analyzeFile(cwd, file, options);
 
     for (let key of translationKeys) {
       if (allTranslationKeys.has(key)) {
@@ -195,11 +202,14 @@ async function analyzeFiles(cwd, files, options) {
   return allTranslationKeys;
 }
 
-async function analyzeFile(cwd, file, options) {
+function analyzeFile(cwd, file, options) {
   let content = fs.readFileSync(`${cwd}/${file}`, 'utf8');
   let extension = path.extname(file).toLowerCase();
+  let { includeGtsExtension } = options;
 
-  if (['.js', ...options.userExtensions].includes(extension)) {
+  if ('.gjs' === extension || (includeGtsExtension && '.gts' === extension)) {
+    return analyzeGJSFile(content, options);
+  } else if (['.js', ...options.userExtensions].includes(extension)) {
     return analyzeJsFile(content, options.userPlugins);
   } else if (extension === '.hbs') {
     return analyzeHbsFile(content, options);
@@ -211,7 +221,52 @@ async function analyzeFile(cwd, file, options) {
   }
 }
 
-async function analyzeJsFile(content, userPlugins) {
+function analyzeGJSFile(gjsGtsContent, options) {
+  const jsTsContent = contentTag.process(gjsGtsContent);
+
+  const ast = BabelParser.parse(jsTsContent, {
+    sourceType: 'module',
+    plugins: [
+      'decorators-legacy',
+      'dynamicImport',
+      'classProperties',
+      'classStaticBlock',
+      ...options.userPlugins,
+    ],
+  });
+
+  let templates = [];
+  traverse(ast, {
+    CallExpression(path) {
+      const { node } = path;
+      let { callee } = node;
+      if (callee.name !== 'template') {
+        return;
+      }
+
+      const callScopeBinding = path.scope.getBinding('template');
+
+      if (
+        callScopeBinding.kind === 'module' &&
+        callScopeBinding.path.parent.source.value === '@ember/template-compiler'
+      ) {
+        const { start, end } = node.arguments[0];
+        const templateContent = jsTsContent.substring(start + 1, end - 1);
+        templates.push(templateContent);
+      }
+    },
+  });
+
+  const keysFromJs = [...analyzeJsFile(jsTsContent, options.userPlugins)];
+
+  const keysFromHbs = templates.reduce((keys, template) => {
+    return [...keys, ...analyzeHbsFile(template, options)];
+  }, []);
+
+  return new Set([...keysFromJs, ...keysFromHbs]);
+}
+
+function analyzeJsFile(content, userPlugins) {
   let translationKeys = new Set();
 
   // parse the JS file
@@ -248,7 +303,7 @@ async function analyzeJsFile(content, userPlugins) {
   return translationKeys;
 }
 
-async function analyzeHbsFile(content, { analyzeConcatExpression = false }) {
+function analyzeHbsFile(content, { analyzeConcatExpression = false }) {
   let translationKeys = new Set();
 
   // parse the HBS file
@@ -325,7 +380,7 @@ async function analyzeHbsFile(content, { analyzeConcatExpression = false }) {
   return translationKeys;
 }
 
-async function analyzeTranslationFiles(cwd, files) {
+function analyzeTranslationFiles(cwd, files) {
   let existingTranslationKeys = new Map();
 
   for (let file of files) {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@babel/traverse": "^7.13.17",
     "@glimmer/syntax": "^0.80.0",
     "chalk": "^4.1.1",
+    "content-tag": "^1.1.2",
     "emblem": "^0.12.1",
     "esm": "^3.2.25",
     "globby": "^11.0.3",

--- a/test.js
+++ b/test.js
@@ -28,6 +28,10 @@ describe('Test Fixtures', () => {
       babelParserPlugins: ['typescript'],
       extensions: ['.ts'],
     },
+    'first-class-component-templates': {
+      babelParserPlugins: ['typescript'],
+      extensions: ['.gts'],
+    },
   };
 
   beforeEach(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1776,6 +1776,11 @@ configstore@^5.0.1:
     write-file-atomic "^3.0.0"
     xdg-basedir "^4.0.0"
 
+content-tag@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/content-tag/-/content-tag-1.1.2.tgz#a7adddfdd2d44c9418b795c91ee04c55f570a997"
+  integrity sha512-AZkfc6TUmW+/RbZJioPzOQPAHHXqyqK4B0GNckJDjBAPK3SyGrMfn21bfFky/qwi5uoLph5sjAHUkO3CL6/IgQ==
+
 convert-source-map@^1.4.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.9.0.tgz#7faae62353fb4213366d0ca98358d22e8368b05f"


### PR DESCRIPTION
How this works:

* Use [content-tag](https://github.com/embroider-build/content-tag) to transpile `.gjs/.gts` into spec compliant Javascrip/Typescript see https://rfcs.emberjs.com/id/0931-template-compiler-api/
* Run `analyzeJSFile` on the transpiled JS
* Use Babel to extract templates string from transpiled JS and then run `analyzeHbsFile` on the templates
* Merge and return all the keys found