### PR TITLE
Add custom t helper support

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,21 @@ If your application has a lot of unused translations you can run the command wit
 the `--fix` to remove them. Remember to double check your translations as dynamic
 translations need to be whitelisted or they will be removed!
 
+### `Custom t helpers`
+
+By default this package will only check templates for `ember-intl`'s `t` helper, but
+in some cases you may want to create a custom wrapping helper e.g. `{{t-error 'error.key' error}}`
+this helper could manage generic error situation but also accept a custom error key.
+If your app uses custom `t` helpers you can register them in you config under the helpers key.
+
+**Note: This requires the translation key to be the first parameter of the helper**
+
+```js
+export default {
+  helpers: ['t-error'],
+};
+```
+
 Caveats
 ------------------------------------------------------------------------------
 

--- a/__snapshots__/test.js.snap
+++ b/__snapshots__/test.js.snap
@@ -33,6 +33,20 @@ exports[`Test Fixtures concat-expression 1`] = `
 
 exports[`Test Fixtures concat-expression 2`] = `Map {}`;
 
+exports[`Test Fixtures custom-t-helpers 1`] = `
+"[1/4] 🔍  Finding JS and HBS files...
+[2/4] 🔍  Searching for translations keys in JS and HBS files...
+[3/4] ⚙️   Checking for unused translations...
+[4/4] ⚙️   Checking for missing translations...
+
+ 👏  No unused translations were found!
+
+ 👏  No missing translations were found!
+"
+`;
+
+exports[`Test Fixtures custom-t-helpers 2`] = `Map {}`;
+
 exports[`Test Fixtures decorators 1`] = `
 "[1/4] 🔍  Finding JS and HBS files...
 [2/4] 🔍  Searching for translations keys in JS and HBS files...

--- a/fixtures/custom-t-helpers/app/controllers/application.js
+++ b/fixtures/custom-t-helpers/app/controllers/application.js
@@ -1,0 +1,7 @@
+import Controller from '@ember/controller';
+
+export default Controller.extend({
+  foo: computed('intl.locale', function() {
+    return this.intl.t('js-translation');
+  }),
+});

--- a/fixtures/custom-t-helpers/app/templates/application.hbs
+++ b/fixtures/custom-t-helpers/app/templates/application.hbs
@@ -1,0 +1,2 @@
+{{t "hbs-translation"}}
+{{t-error "custom-t-helper"}}

--- a/fixtures/custom-t-helpers/translations/de.json
+++ b/fixtures/custom-t-helpers/translations/de.json
@@ -1,0 +1,5 @@
+{
+  "hbs-translation": "Lenkstage",
+  "js-translation": "Affentheater",
+  "custom-t-helper": "foobar"
+}

--- a/fixtures/custom-t-helpers/translations/en.json
+++ b/fixtures/custom-t-helpers/translations/en.json
@@ -1,0 +1,4 @@
+{
+  "hbs-translation": "HBS!",
+  "js-translation": "JS!",
+}

--- a/test.js
+++ b/test.js
@@ -40,6 +40,9 @@ describe('Test Fixtures', () => {
         /some\.unused\.whitelisted\.translation-(a|b)/,
       ],
     },
+    'custom-t-helpers': {
+      helpers: ['t-error'],
+    },
   };
 
   beforeEach(() => {


### PR DESCRIPTION
Implements #615 

Some users use custom `t` helpers, this allows users to let `ember-intl-analyzer` know about custom t helpers so they no longer need to be whitelisted.