### PR TITLE
fix: dont use deprecated esm package to load config file in Node 22

### DIFF
--- a/index.js
+++ b/index.js
@@ -155,8 +155,13 @@ function readConfig(cwd) {
 
   let config = {};
   if (fs.existsSync(configPath)) {
-    let requireESM = require('esm')(module, { cjs: { dedefault: true } });
-    config = requireESM(configPath);
+    const majorNodeVersion = parseInt(process.version.slice(1).split('.')[0], 10);
+    if (majorNodeVersion < 22) {
+      let requireESM = require('esm')(module, { cjs: { dedefault: true } });
+      config = requireESM(configPath);
+    } else {
+      config = require(configPath).default;
+    }
   }
 
   return config;


### PR DESCRIPTION
Fixes #687

I am not super familiar with esm so maybe there is a better, more generic way to fix this. The package used [esm](https://github.com/standard-things/esm) is archived so probably it should be removed alltogether. 

I tested this with a clean Ember app on both node 20 and node 22 and it did work.